### PR TITLE
Remove xdg-data filesystem permission

### DIFF
--- a/com.mousepawmedia.omission.yaml
+++ b/com.mousepawmedia.omission.yaml
@@ -13,7 +13,6 @@ cleanup:
     - "*.a"
     - "*.la"
 finish-args:
-    - --filesystem=xdg-data
     - --share=ipc
     - --socket=x11
     - --socket=wayland


### PR DESCRIPTION
It looks like Omission runs happily without this permission (I tried using Flatseal to change it locally). It's obviously desirable for sandboxed applications to have only the permissions they need.

I can see that it writes `scores.data` under $XDG_DATA_HOME. But inside Flatpak, this is automatically set to an isolated directory which you don't need special permissions to access, for precisely this kind of use. At least on my system, these per-app directories live under `~/.var/app`.